### PR TITLE
Improve the opam file

### DIFF
--- a/reanalyze.opam
+++ b/reanalyze.opam
@@ -1,6 +1,8 @@
 opam-version: "2.0"
-description:
-  "Experimental analyses for OCaml/Reason: for globally dead values/types, exception analysis, and termination analysis."
+synopsis: "Dead values/types, exception, and termination analysis for OCaml/Reason"
+description: """
+Experimental analyses for OCaml/Reason: for globally dead values/types, exception analysis, and termination analysis.
+"""
 maintainer: ["Cristiano Calcagno"]
 authors: ["Cristiano Calcagno"]
 license: "MIT"
@@ -8,11 +10,11 @@ homepage: "https://github.com/reason-association/reanalyze"
 bug-reports: "https://github.com/reason-association/reanalyze/issues"
 depends: [
   "dune" {>= "1.7"}
-  "ocaml" {< "4.12" & >= "4.06.1"}
+  "ocaml" {>= "4.06.1" & < "4.12"}
   "reason" {>= "3.6.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
As explained in https://github.com/reason-association/reanalyze/issues/100, here are some improvements to the opam file I used in https://github.com/ocaml/opam-repository/pull/17298

This PR:
* adds a synopsis: a shorter description shown in `opam search` for instance
* rearranges the ocaml upper-bound to be on the right (more common)
* Uses `{dev}` instead of `{pinned}` when calling `dune subst` (see https://github.com/ocaml/dune/pull/3647)