### PR TITLE
Allow the package to be compiled on OCaml 4.12

### DIFF
--- a/reanalyze.opam
+++ b/reanalyze.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/reason-association/reanalyze"
 bug-reports: "https://github.com/reason-association/reanalyze/issues"
 depends: [
   "dune" {>= "1.7"}
-  "ocaml" {>= "4.06.1" & < "4.12"}
+  "ocaml" {>= "4.06.1" & < "4.13"}
   "reason" {>= "3.6.0"}
 ]
 build: [


### PR DESCRIPTION
The `master` branch currently compiles perfectly with the soon upcoming OCaml 4.12.

Would it be possible to get a release to get the compatibility with OCaml 4.11 and 4.12? I can release it on opam like last time if you need.