### PR TITLE
Fix DCE false positives on ReScript compiler CMT analysis

### DIFF
--- a/examples/regression/.gitignore
+++ b/examples/regression/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/_build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/examples/regression/dune-project
+++ b/examples/regression/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.0)
+
+(name regression)

--- a/examples/regression/src/Functor_argument.ml
+++ b/examples/regression/src/Functor_argument.ml
@@ -1,0 +1,9 @@
+module Ordered = struct
+  type t = int
+
+  let compare (left : int) right = Stdlib.compare left right
+end
+
+module Int_set = Set.Make (Ordered)
+
+let use_set () = ignore (Int_set.singleton 1)

--- a/examples/regression/src/Functor_argument.ml
+++ b/examples/regression/src/Functor_argument.ml
@@ -2,8 +2,27 @@ module Ordered = struct
   type t = int
 
   let compare (left : int) right = Stdlib.compare left right
+  let unused () = ()
 end
 
 module Int_set = Set.Make (Ordered)
 
 let use_set () = ignore (Int_set.singleton 1)
+
+module Extra_fields = struct
+  type extension = ..
+  type extension += Extra
+
+  let before () = ()
+end
+
+module Anonymous_set = Set.Make (struct
+  include Extra_fields
+
+  type t = int
+
+  let compare (left : int) right = Stdlib.compare left right
+  let unused () = ()
+end)
+
+let use_anonymous_set () = ignore (Anonymous_set.singleton 1)

--- a/examples/regression/src/Generated_source.ml
+++ b/examples/regression/src/Generated_source.ml
@@ -1,0 +1,2 @@
+# 1 "generated_source.cppo.ml"
+let () = ()

--- a/examples/regression/src/Live_ancestors.ml
+++ b/examples/regression/src/Live_ancestors.ml
@@ -1,0 +1,9 @@
+module Parent = struct
+  let dead_top () = ()
+
+  module Child = struct
+    let live () = ()
+  end
+end
+
+let use_child () = Parent.Child.live ()

--- a/examples/regression/src/Local_side_effects.ml
+++ b/examples/regression/src/Local_side_effects.ml
@@ -1,0 +1,10 @@
+let registry = ref []
+
+let register callback =
+  registry := callback :: !registry;
+  List.length !registry
+
+let start () =
+  let process () = () in
+  let _info = register process in
+  ()

--- a/examples/regression/src/Main.ml
+++ b/examples/regression/src/Main.ml
@@ -1,0 +1,1 @@
+let definitely_dead () = ()

--- a/examples/regression/src/Main.ml
+++ b/examples/regression/src/Main.ml
@@ -3,4 +3,5 @@ let definitely_dead () = ()
 let () =
   Live_ancestors.use_child ();
   Functor_argument.use_set ();
+  Functor_argument.use_anonymous_set ();
   Local_side_effects.start ()

--- a/examples/regression/src/Main.ml
+++ b/examples/regression/src/Main.ml
@@ -2,4 +2,5 @@ let definitely_dead () = ()
 
 let () =
   Live_ancestors.use_child ();
-  Functor_argument.use_set ()
+  Functor_argument.use_set ();
+  Local_side_effects.start ()

--- a/examples/regression/src/Main.ml
+++ b/examples/regression/src/Main.ml
@@ -1,3 +1,5 @@
 let definitely_dead () = ()
 
-let () = Live_ancestors.use_child ()
+let () =
+  Live_ancestors.use_child ();
+  Functor_argument.use_set ()

--- a/examples/regression/src/Main.ml
+++ b/examples/regression/src/Main.ml
@@ -1,1 +1,3 @@
 let definitely_dead () = ()
+
+let () = Live_ancestors.use_child ()

--- a/examples/regression/src/dune
+++ b/examples/regression/src/dune
@@ -1,0 +1,4 @@
+(library
+ (name regression_fixture)
+ (modules Generated_source Main)
+ (flags :standard -w -27-32-34-37-39 -bin-annot))

--- a/examples/regression/src/dune
+++ b/examples/regression/src/dune
@@ -1,4 +1,9 @@
 (library
  (name regression_fixture)
- (modules Functor_argument Generated_source Live_ancestors Main)
+ (modules
+  Functor_argument
+  Generated_source
+  Live_ancestors
+  Local_side_effects
+  Main)
  (flags :standard -w -27-32-34-37-39 -bin-annot))

--- a/examples/regression/src/dune
+++ b/examples/regression/src/dune
@@ -1,4 +1,4 @@
 (library
  (name regression_fixture)
- (modules Generated_source Main)
+ (modules Generated_source Live_ancestors Main)
  (flags :standard -w -27-32-34-37-39 -bin-annot))

--- a/examples/regression/src/dune
+++ b/examples/regression/src/dune
@@ -1,4 +1,4 @@
 (library
  (name regression_fixture)
- (modules Generated_source Live_ancestors Main)
+ (modules Functor_argument Generated_source Live_ancestors Main)
  (flags :standard -w -27-32-34-37-39 -bin-annot))

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -96,6 +96,8 @@ function runRegressionTests() {
 
   assertIncludes(output, "+definitely_dead is never used");
   assertIncludes(output, "Source:src/Generated_source.ml");
+
+  assertNotIncludes(output, "Parent is a dead module");
 }
 
 function checkSetup() {

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -96,8 +96,10 @@ function runRegressionTests() {
 
   assertIncludes(output, "+definitely_dead is never used");
   assertIncludes(output, "Source:src/Generated_source.ml");
+  assertIncludes(output, "Live Value +Functor_argument.Ordered.+compare");
 
   assertNotIncludes(output, "Parent is a dead module");
+  assertNotIncludes(output, "Dead Value +Functor_argument.Ordered.+compare");
 }
 
 function checkSetup() {

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -97,9 +97,15 @@ function runRegressionTests() {
   assertIncludes(output, "+definitely_dead is never used");
   assertIncludes(output, "Source:src/Generated_source.ml");
   assertIncludes(output, "Live Value +Functor_argument.Ordered.+compare");
+  assertIncludes(output, "Live Value +Local_side_effects.+_info");
+  assertIncludes(output, "Live Value +Local_side_effects.+process");
+  assertIncludes(output, "Live Value +Local_side_effects.+register");
 
   assertNotIncludes(output, "Parent is a dead module");
   assertNotIncludes(output, "Dead Value +Functor_argument.Ordered.+compare");
+  assertNotIncludes(output, "Dead Value +Local_side_effects.+_info");
+  assertNotIncludes(output, "Dead Value +Local_side_effects.+process");
+  assertNotIncludes(output, "Dead Value +Local_side_effects.+register");
 }
 
 function checkSetup() {

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -97,12 +97,18 @@ function runRegressionTests() {
   assertIncludes(output, "+definitely_dead is never used");
   assertIncludes(output, "Source:src/Generated_source.ml");
   assertIncludes(output, "Live Value +Functor_argument.Ordered.+compare");
+  assertIncludes(output, "Dead Value +Functor_argument.Ordered.+unused");
+  assertIncludes(output, "Live Value +Functor_argument.Anonymous_set.+compare");
+  assertIncludes(output, "Dead Value +Functor_argument.Anonymous_set.+unused");
   assertIncludes(output, "Live Value +Local_side_effects.+_info");
   assertIncludes(output, "Live Value +Local_side_effects.+process");
   assertIncludes(output, "Live Value +Local_side_effects.+register");
 
   assertNotIncludes(output, "Parent is a dead module");
   assertNotIncludes(output, "Dead Value +Functor_argument.Ordered.+compare");
+  assertNotIncludes(output, "Live Value +Functor_argument.Ordered.+unused");
+  assertNotIncludes(output, "Dead Value +Functor_argument.Anonymous_set.+compare");
+  assertNotIncludes(output, "Live Value +Functor_argument.Anonymous_set.+unused");
   assertNotIncludes(output, "Dead Value +Local_side_effects.+_info");
   assertNotIncludes(output, "Dead Value +Local_side_effects.+process");
   assertNotIncludes(output, "Dead Value +Local_side_effects.+register");

--- a/scripts/run_integration_tests.js
+++ b/scripts/run_integration_tests.js
@@ -58,6 +58,46 @@ function checkDiff() {
   });
 }
 
+function assertIncludes(output, expected) {
+  if (!output.includes(expected)) {
+    throw new Error(`Expected regression output to contain:\n${expected}`);
+  }
+}
+
+function assertNotIncludes(output, unexpected) {
+  if (output.includes(unexpected)) {
+    throw new Error(`Regression output unexpectedly contained:\n${unexpected}`);
+  }
+}
+
+function runRegressionTests() {
+  const cwd = path.join(__dirname, "..", "examples", "regression");
+  const cmtDir = "_build/default/src/.regression_fixture.objs/byte";
+
+  console.log(`${cwd}: dune clean && dune build`);
+  child_process.execFileSync("dune", ["clean", "--root", "."], {
+    cwd,
+    stdio: [0, 1, 2],
+  });
+  child_process.execFileSync("dune", ["build", "--root", "."], {
+    cwd,
+    stdio: [0, 1, 2],
+  });
+
+  console.log(`${cwd}: reanalyze regression assertions`);
+  const output = child_process.execFileSync(
+    reanalyzeFile,
+    ["-ci", "-debug", "-native-build-target", ".", "-dce-cmt", cmtDir],
+    {
+      cwd,
+      encoding: "utf8",
+    }
+  );
+
+  assertIncludes(output, "+definitely_dead is never used");
+  assertIncludes(output, "Source:src/Generated_source.ml");
+}
+
 function checkSetup() {
   console.log("Checking if --version outputs the right version");
   let output;
@@ -89,6 +129,7 @@ function main() {
   try {
     checkSetup();
     cleanBuildExamples();
+    runRegressionTests();
     checkDiff();
 
     console.log("Test successful!");

--- a/src/DeadModules.ml
+++ b/src/DeadModules.ml
@@ -2,6 +2,20 @@ let active () = true
 
 let table = Hashtbl.create 1
 
+let moduleAncestors moduleName =
+  let parts = String.split_on_char '.' moduleName in
+  let rec loop prefix parts acc =
+    match parts with
+    | [] -> acc
+    | "" :: rest -> loop prefix rest acc
+    | part :: rest ->
+      let prefix =
+        match prefix with "" -> part | _ -> prefix ^ "." ^ part
+      in
+      loop prefix rest (prefix :: acc)
+  in
+  loop "" parts []
+
 let markDead ~isType ~loc path =
   if active () then
     let moduleName = path |> Common.Path.toModuleName ~isType in
@@ -12,10 +26,13 @@ let markDead ~isType ~loc path =
 let markLive ~isType ~(loc : Location.t) path =
   if active () then
     let moduleName = path |> Common.Path.toModuleName ~isType in
-    match Hashtbl.find_opt table moduleName with
-    | None -> Hashtbl.replace table moduleName (true, loc)
-    | Some (false, loc) -> Hashtbl.replace table moduleName (true, loc)
-    | Some (true, _) -> ()
+    (* A live nested item keeps each enclosing module live too. *)
+    moduleName |> moduleAncestors
+    |> List.iter (fun moduleName ->
+           match Hashtbl.find_opt table moduleName with
+           | None -> Hashtbl.replace table moduleName (true, loc)
+           | Some (false, loc) -> Hashtbl.replace table moduleName (true, loc)
+           | Some (true, _) -> ())
 
 let checkModuleDead ~fileName:pos_fname moduleName =
   if active () then

--- a/src/DeadValue.ml
+++ b/src/DeadValue.ml
@@ -275,24 +275,90 @@ let rec getSignature (moduleType : Types.module_type) =
     | _ -> [])
   | _ -> []
 
-let rec addModuleValueReferences ~locFrom (moduleType : Types.module_type) =
+let nth_opt items index =
+  if index < 0 then None else try Some (List.nth items index) with _ -> None
+
+let signatureItemName (signatureItem : Types.signature_item) =
+  match signatureItem with
+  | Types.Sig_value _ ->
+    let id, _loc, _kind, _valType = signatureItem |> Compat.getSigValue in
+    Some (Ident.name id)
+  | Types.Sig_module _ | Types.Sig_modtype _ -> (
+    match signatureItem |> Compat.getSigModuleModtype with
+    | Some (id, _moduleType, _moduleLoc) -> Some (Ident.name id)
+    | None -> None)
+  | _ -> None
+
+let findSignatureItem name signature =
+  signature
+  |> List.find_opt (fun signatureItem ->
+         match signatureItemName signatureItem with
+         | Some itemName -> itemName = name
+         | None -> false)
+
+let addValueReferenceFromSignatureItem ~locFrom signatureItem =
+  let _id, locTo, _kind, _valType = signatureItem |> Compat.getSigValue in
+  if not locTo.loc_ghost then
+    addValueReference ~addFileReference:true ~locFrom ~locTo
+
+let rec addAllModuleValueReferences ~locFrom (moduleType : Types.module_type) =
   moduleType |> getSignature
   |> List.iter (fun (signatureItem : Types.signature_item) ->
          match signatureItem with
          | Types.Sig_value _ ->
-           let _id, locTo, _kind, _valType =
-             signatureItem |> Compat.getSigValue
-           in
-           if not locTo.loc_ghost then
-             addValueReference ~addFileReference:true ~locFrom ~locTo
+           addValueReferenceFromSignatureItem ~locFrom signatureItem
          | Types.Sig_module _ | Types.Sig_modtype _ -> (
-           (* Functor arguments are used through their module signatures, so
-              mark nested signature values such as Set.OrderedType.compare. *)
            match signatureItem |> Compat.getSigModuleModtype with
            | Some (_id, moduleType, _moduleLoc) ->
-             addModuleValueReferences ~locFrom moduleType
+             addAllModuleValueReferences ~locFrom moduleType
            | None -> ())
          | _ -> ())
+
+let rec addCoercedModuleValueReferences ~locFrom ~coercion ~actualType =
+  let actualSignature = actualType |> getSignature in
+  match coercion with
+  | Typedtree.Tcoerce_none -> addAllModuleValueReferences ~locFrom actualType
+  | Typedtree.Tcoerce_structure (values, modules) ->
+    let actualFields =
+      actualSignature
+      |> List.filter (function
+           | Types.Sig_type _ | Types.Sig_module _ | Types.Sig_modtype _ ->
+             false
+           | _ -> true)
+    in
+    values
+    |> List.iter (fun (index, _coercion) ->
+           match nth_opt actualFields index with
+           | Some (Types.Sig_value _ as actualItem) ->
+             addValueReferenceFromSignatureItem ~locFrom actualItem
+           | Some _ -> ()
+           | None -> ());
+    let actualModules =
+      actualSignature
+      |> List.filter (function
+           | Types.Sig_module _ | Types.Sig_modtype _ -> true
+           | _ -> false)
+    in
+    modules
+    |> List.iter (fun (id, index, coercion) ->
+           let actualItem =
+             match actualSignature |> findSignatureItem (Ident.name id) with
+             | Some item -> Some item
+             | None -> nth_opt actualModules index
+           in
+           match actualItem with
+           | Some actualItem -> (
+             match actualItem |> Compat.getSigModuleModtype with
+             | Some (_actualId, actualType, _moduleLoc) ->
+               addCoercedModuleValueReferences ~locFrom ~coercion ~actualType
+             | None -> ())
+           | None -> ())
+  | Typedtree.Tcoerce_alias (_env, _path, coercion) ->
+    addCoercedModuleValueReferences ~locFrom ~coercion ~actualType
+  | Typedtree.Tcoerce_functor (_argCoercion, resultCoercion) ->
+    addCoercedModuleValueReferences ~locFrom ~coercion:resultCoercion
+      ~actualType
+  | Typedtree.Tcoerce_primitive _ -> ()
 
 let rec processSignatureItem ~doTypes ~doValues ~moduleLoc ~path
     (si : Types.signature_item) =
@@ -335,9 +401,11 @@ let traverseStructure ~doTypes ~doExternals =
   let pat self p = p |> collectPattern super self in
   let module_expr self (moduleExpr : Typedtree.module_expr) =
     (match moduleExpr.mod_desc with
-    | Tmod_apply (_functorExpr, argumentExpr, _coercion) ->
-      addModuleValueReferences ~locFrom:argumentExpr.mod_loc
-        argumentExpr.mod_type
+    | Tmod_apply (_functorExpr, argumentExpr, coercion) ->
+      (* Functor arguments are used through the parameter coercion, not every
+         value exposed by the actual argument module. *)
+      addCoercedModuleValueReferences ~locFrom:argumentExpr.mod_loc ~coercion
+        ~actualType:argumentExpr.mod_type
     | _ -> ());
     super.Tast_mapper.module_expr self moduleExpr
   in

--- a/src/DeadValue.ml
+++ b/src/DeadValue.ml
@@ -50,13 +50,17 @@ let collectValueBinding super self (vb : Typedtree.value_binding) =
         | Tpackage _ -> true
         | _ -> false
       in
+      let isToplevel = oldLastBinding = Location.none in
+      let sideEffects = SideEffects.checkExpr vb.vb_expr in
       (if (not exists) && not isFirstClassModule then
-       (* This is never toplevel currently *)
-       let isToplevel = oldLastBinding = Location.none in
-       let sideEffects = SideEffects.checkExpr vb.vb_expr in
        name
        |> addValueDeclaration ~isToplevel ~loc ~moduleLoc:currentModulePath.loc
             ~optionalArgs ~path ~sideEffects);
+      (* Keep side-effectful local lets reachable from the enclosing binding,
+         even when the local name itself is not read. *)
+      (if (not isToplevel) && sideEffects then
+       addValueReference ~addFileReference:false ~locFrom:oldLastBinding
+         ~locTo:loc);
       (match PosHash.find_opt decls loc_start with
       | None -> ()
       | Some decl ->

--- a/src/DeadValue.ml
+++ b/src/DeadValue.ml
@@ -271,6 +271,25 @@ let rec getSignature (moduleType : Types.module_type) =
     | _ -> [])
   | _ -> []
 
+let rec addModuleValueReferences ~locFrom (moduleType : Types.module_type) =
+  moduleType |> getSignature
+  |> List.iter (fun (signatureItem : Types.signature_item) ->
+         match signatureItem with
+         | Types.Sig_value _ ->
+           let _id, locTo, _kind, _valType =
+             signatureItem |> Compat.getSigValue
+           in
+           if not locTo.loc_ghost then
+             addValueReference ~addFileReference:true ~locFrom ~locTo
+         | Types.Sig_module _ | Types.Sig_modtype _ -> (
+           (* Functor arguments are used through their module signatures, so
+              mark nested signature values such as Set.OrderedType.compare. *)
+           match signatureItem |> Compat.getSigModuleModtype with
+           | Some (_id, moduleType, _moduleLoc) ->
+             addModuleValueReferences ~locFrom moduleType
+           | None -> ())
+         | _ -> ())
+
 let rec processSignatureItem ~doTypes ~doValues ~moduleLoc ~path
     (si : Types.signature_item) =
   match si with
@@ -310,6 +329,14 @@ let traverseStructure ~doTypes ~doExternals =
   let super = Tast_mapper.default in
   let expr self e = e |> collectExpr super self in
   let pat self p = p |> collectPattern super self in
+  let module_expr self (moduleExpr : Typedtree.module_expr) =
+    (match moduleExpr.mod_desc with
+    | Tmod_apply (_functorExpr, argumentExpr, _coercion) ->
+      addModuleValueReferences ~locFrom:argumentExpr.mod_loc
+        argumentExpr.mod_type
+    | _ -> ());
+    super.Tast_mapper.module_expr self moduleExpr
+  in
   let value_binding self vb = vb |> collectValueBinding super self in
   let structure_item self (structureItem : Typedtree.structure_item) =
     let oldModulePath = ModulePath.getCurrent () in
@@ -386,7 +413,7 @@ let traverseStructure ~doTypes ~doExternals =
     ModulePath.setCurrent oldModulePath;
     result
   in
-  {super with expr; pat; structure_item; value_binding}
+  {super with expr; module_expr; pat; structure_item; value_binding}
 
 (* Merge a location's references to another one's *)
 let processValueDependency

--- a/src/FindSourceFile.ml
+++ b/src/FindSourceFile.ml
@@ -1,37 +1,59 @@
+let concatRelative root fname =
+  match Filename.is_relative fname with
+  | true -> Filename.concat root fname
+  | false -> fname
+
 (** Prepend nativeBuildTarget to fname when provided (-native-build-target) *)
 let nativeFilePath fname =
   match !Common.Cli.nativeBuildTarget with
   | None -> fname
-  | Some nativeBuildTarget -> Filename.concat nativeBuildTarget fname
+  | Some nativeBuildTarget -> concatRelative nativeBuildTarget fname
 
-let rec interface items =
+let sourceExists ?cmtRoot fname =
+  Sys.file_exists (nativeFilePath fname)
+  ||
+  (* In -dce-cmt mode, source paths in CMT metadata can be relative to the
+     scanned build root rather than the current working directory. *)
+  match cmtRoot with
+  | Some root -> Sys.file_exists (concatRelative root fname)
+  | None -> false
+
+let rec interface ?cmtRoot items =
   match items with
   | {Typedtree.sig_loc} :: rest -> (
-    match
-      not (Sys.file_exists (nativeFilePath sig_loc.loc_start.pos_fname))
-    with
-    | true -> interface rest
-    | false -> Some sig_loc.loc_start.pos_fname)
+    match sourceExists ?cmtRoot sig_loc.loc_start.pos_fname with
+    | false -> interface ?cmtRoot rest
+    | true -> Some sig_loc.loc_start.pos_fname)
   | [] -> None
 
-let rec implementation items =
+let rec implementation ?cmtRoot items =
   match items with
   | {Typedtree.str_loc} :: rest -> (
-    match
-      not (Sys.file_exists (nativeFilePath str_loc.loc_start.pos_fname))
-    with
-    | true -> implementation rest
-    | false -> Some str_loc.loc_start.pos_fname)
+    match sourceExists ?cmtRoot str_loc.loc_start.pos_fname with
+    | false -> implementation ?cmtRoot rest
+    | true -> Some str_loc.loc_start.pos_fname)
   | [] -> None
 
-let cmt cmt_annots =
-  match cmt_annots with
+let sourcefile ?cmtRoot (cmt_infos : Cmt_format.cmt_infos) =
+  match cmt_infos.cmt_sourcefile with
+  | Some sourceFile when sourceExists ?cmtRoot sourceFile -> Some sourceFile
+  | _ -> None
+
+let cmt ?cmtRoot (cmt_infos : Cmt_format.cmt_infos) =
+  (* Preprocessed/generated locations can point at files that are not present
+     locally; cmt_sourcefile usually still names the real source file. *)
+  let fallback () = sourcefile ?cmtRoot cmt_infos in
+  match cmt_infos.cmt_annots with
   | Cmt_format.Interface signature ->
     if !Common.Cli.debug && signature.sig_items = [] then
       Log_.item "Interface %d@." (signature.sig_items |> List.length);
-    interface signature.sig_items
+    (match interface ?cmtRoot signature.sig_items with
+    | Some sourceFile -> Some sourceFile
+    | None -> fallback ())
   | Implementation structure ->
     if !Common.Cli.debug && structure.str_items = [] then
       Log_.item "Implementation %d@." (structure.str_items |> List.length);
-    implementation structure.str_items
+    (match implementation ?cmtRoot structure.str_items with
+    | Some sourceFile -> Some sourceFile
+    | None -> fallback ())
   | _ -> None

--- a/src/Reanalyze.ml
+++ b/src/Reanalyze.ml
@@ -1,6 +1,6 @@
 open Common
 
-let loadCmtFile cmtFilePath =
+let loadCmtFile ~cmtRoot cmtFilePath =
   let cmt_infos = Cmt_format.read_cmt cmtFilePath in
   let excludePath sourceFile =
     !Cli.excludePaths
@@ -15,7 +15,7 @@ let loadCmtFile cmtFilePath =
            try String.sub sourceFile 0 (String.length prefix) = prefix
            with Invalid_argument _ -> false)
   in
-  match cmt_infos.cmt_annots |> FindSourceFile.cmt with
+  match FindSourceFile.cmt ?cmtRoot cmt_infos with
   | Some sourceFile when not (excludePath sourceFile) ->
     if !Cli.debug then
       Log_.item "Scanning %s Source:%s@."
@@ -43,7 +43,7 @@ let processCmtFiles ~cmtRoot =
     Filename.check_suffix path ".cmt" || Filename.check_suffix path ".cmti"
   in
   let processCmtFilePaths cmtFilePaths =
-    cmtFilePaths |> List.iter loadCmtFile
+    cmtFilePaths |> List.iter (loadCmtFile ~cmtRoot)
   in
   match cmtRoot with
   | Some root ->


### PR DESCRIPTION
This fixes several DCE false positives found while running `reanalyze -dce-cmt _build/default` against the ReScript compiler after `dune build @check`.

The issues were mostly around CMT-based analysis losing liveness information in compiler-shaped code:

- fallback to `cmt_sourcefile` when typedtree locations point at missing generated/preprocessed files, like `*.cppo.ml`
- keep parent modules live when nested module values are live
- mark values from functor argument signatures as referenced, e.g. `Set.Make(Ordered).compare`
- keep side-effectful local lets live from their enclosing binding

Each fix is paired with a regression test that fails on `ocaml-5-3` and passes with the fix.